### PR TITLE
Configure the Cassandra keyspace in the template

### DIFF
--- a/$name__norm$-impl/src/main/resources/application.conf
+++ b/$name__norm$-impl/src/main/resources/application.conf
@@ -4,3 +4,21 @@
 play.crypto.secret=whatever
 play.modules.enabled += $organization$.$name;format="camel"$.impl.$name;format="Camel"$Module
 
+$name;format="norm"$.cassandra.keyspace = $name;format="lower,snake"$
+
+$!
+The unusual syntax below is because this file is proccessed by StringTemplate.
+We are using StringTemplate properties to construct a config key name,
+which is then used in a HOCON substitution.
+
+The results, if name = hello, should look like this:
+
+cassandra-journal.keyspace = ${hello.cassandra.keyspace}
+cassandra-snapshot-store.keyspace = ${hello.cassandra.keyspace}
+lagom.persistence.read-side.cassandra.keyspace = ${hello.cassandra.keyspace}
+
+Also note that this comment is a StringTemplate comment and is not included in the output.
+!$
+cassandra-journal.keyspace = \${$name;format="norm"$.cassandra.keyspace}
+cassandra-snapshot-store.keyspace = \${$name;format="norm"$.cassandra.keyspace}
+lagom.persistence.read-side.cassandra.keyspace = \${$name;format="norm"$.cassandra.keyspace}


### PR DESCRIPTION
This will help to ensure that projects won't be affected by changes to the default keyspace configuration.

See #578