### PR TITLE
Use lowercase for package names

### DIFF
--- a/$name__norm$-api/src/main/java/$package$/api/$name__Camel$Service.java
+++ b/$name__norm$-api/src/main/java/$package$/api/$name__Camel$Service.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
  */
-package $organization$.$name;format="camel"$.api;
+package $package$.api;
 
 import static com.lightbend.lagom.javadsl.api.Service.named;
 import static com.lightbend.lagom.javadsl.api.Service.pathCall;

--- a/$name__norm$-api/src/main/java/$package$/api/GreetingMessage.java
+++ b/$name__norm$-api/src/main/java/$package$/api/GreetingMessage.java
@@ -1,4 +1,4 @@
-package $organization$.$name;format="camel"$.api;
+package $package$.api;
 
 import javax.annotation.Nullable;
 import lombok.Value;

--- a/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$Command.java
+++ b/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$Command.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
  */
-package $organization$.$name;format="camel"$.impl;
+package $package$.impl;
 
 import java.util.Optional;
 

--- a/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$Entity.java
+++ b/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$Entity.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
  */
-package $organization$.$name;format="camel"$.impl;
+package $package$.impl;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -9,9 +9,9 @@ import java.util.Optional;
 import com.lightbend.lagom.javadsl.persistence.PersistentEntity;
 
 import akka.Done;
-import $organization$.$name;format="camel"$.impl.$name;format="Camel"$Command.Hello;
-import $organization$.$name;format="camel"$.impl.$name;format="Camel"$Command.UseGreetingMessage;
-import $organization$.$name;format="camel"$.impl.$name;format="Camel"$Event.GreetingMessageChanged;
+import $package$.impl.$name;format="Camel"$Command.Hello;
+import $package$.impl.$name;format="Camel"$Command.UseGreetingMessage;
+import $package$.impl.$name;format="Camel"$Event.GreetingMessageChanged;
 
 /**
  * This is an event sourced entity. It has a state, {@link $name;format="Camel"$State}, which

--- a/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$Event.java
+++ b/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$Event.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
  */
-package $organization$.$name;format="camel"$.impl;
+package $package$.impl;
 
 import javax.annotation.Nullable;
 import lombok.Value;

--- a/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$Module.java
+++ b/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$Module.java
@@ -1,11 +1,11 @@
 /*
  * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
  */
-package $organization$.$name;format="camel"$.impl;
+package $package$.impl;
 
 import com.google.inject.AbstractModule;
 import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport;
-import $organization$.$name;format="camel"$.api.$name;format="Camel"$Service;
+import $package$.api.$name;format="Camel"$Service;
 
 /**
  * The module that binds the $name;format="Camel"$Service so that it can be served.

--- a/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$ServiceImpl.java
+++ b/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$ServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
  */
-package $organization$.$name;format="camel"$.impl;
+package $package$.impl;
 
 import akka.Done;
 import akka.NotUsed;
@@ -13,9 +13,9 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import javax.inject.Inject;
-import $organization$.$name;format="camel"$.api.GreetingMessage;
-import $organization$.$name;format="camel"$.api.$name;format="Camel"$Service;
-import $organization$.$name;format="camel"$.impl.$name;format="Camel"$Command.*;
+import $package$.api.GreetingMessage;
+import $package$.api.$name;format="Camel"$Service;
+import $package$.impl.$name;format="Camel"$Command.*;
 
 /**
  * Implementation of the $name;format="Camel"$Service.

--- a/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$State.java
+++ b/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$State.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
  */
-package $organization$.$name;format="camel"$.impl;
+package $package$.impl;
 
 import javax.annotation.Nullable;
 import lombok.Value;

--- a/$name__norm$-impl/src/main/resources/application.conf
+++ b/$name__norm$-impl/src/main/resources/application.conf
@@ -2,7 +2,7 @@
 # Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
 #
 play.crypto.secret=whatever
-play.modules.enabled += $organization$.$name;format="camel"$.impl.$name;format="Camel"$Module
+play.modules.enabled += $package$.impl.$name;format="Camel"$Module
 
 $name;format="norm"$.cassandra.keyspace = $name;format="lower,snake,word"$
 

--- a/$name__norm$-impl/src/test/java/$package$/impl/$name__Camel$EntityTest.java
+++ b/$name__norm$-impl/src/test/java/$package$/impl/$name__Camel$EntityTest.java
@@ -1,4 +1,4 @@
-package $organization$.$name;format="camel"$.impl;
+package $package$.impl;
 
 import static org.junit.Assert.assertEquals;
 
@@ -15,9 +15,9 @@ import com.lightbend.lagom.javadsl.testkit.PersistentEntityTestDriver.Outcome;
 import akka.Done;
 import akka.actor.ActorSystem;
 import akka.testkit.JavaTestKit;
-import $organization$.$name;format="camel"$.impl.$name;format="Camel"$Command.Hello;
-import $organization$.$name;format="camel"$.impl.$name;format="Camel"$Command.UseGreetingMessage;
-import $organization$.$name;format="camel"$.impl.$name;format="Camel"$Event.GreetingMessageChanged;
+import $package$.impl.$name;format="Camel"$Command.Hello;
+import $package$.impl.$name;format="Camel"$Command.UseGreetingMessage;
+import $package$.impl.$name;format="Camel"$Event.GreetingMessageChanged;
 
 public class $name;format="Camel"$EntityTest {
 

--- a/$name__norm$-impl/src/test/java/$package$/impl/$name__Camel$ServiceTest.java
+++ b/$name__norm$-impl/src/test/java/$package$/impl/$name__Camel$ServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
  */
-package $organization$.$name;format="camel"$.impl;
+package $package$.impl;
 
 import static com.lightbend.lagom.javadsl.testkit.ServiceTest.defaultSetup;
 import static com.lightbend.lagom.javadsl.testkit.ServiceTest.withServer;
@@ -10,8 +10,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-import $organization$.$name;format="camel"$.api.GreetingMessage;
-import $organization$.$name;format="camel"$.api.$name;format="Camel"$Service;
+import $package$.api.GreetingMessage;
+import $package$.api.$name;format="Camel"$Service;
 
 public class $name;format="Camel"$ServiceTest {
 

--- a/$name__norm$-stream-api/src/main/java/$package$stream/api/$name__Camel$StreamService.java
+++ b/$name__norm$-stream-api/src/main/java/$package$stream/api/$name__Camel$StreamService.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
  */
-package $organization$.$name;format="camel"$stream.api;
+package $package$stream.api;
 
 import static com.lightbend.lagom.javadsl.api.Service.named;
 import static com.lightbend.lagom.javadsl.api.Service.namedCall;

--- a/$name__norm$-stream-impl/src/main/java/$package$stream/impl/$name__Camel$StreamModule.java
+++ b/$name__norm$-stream-impl/src/main/java/$package$stream/impl/$name__Camel$StreamModule.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
  */
-package $organization$.$name;format="camel"$stream.impl;
+package $package$stream.impl;
 
 import com.google.inject.AbstractModule;
 import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport;
-import $organization$.$name;format="camel"$.api.$name;format="Camel"$Service;
-import $organization$.$name;format="camel"$stream.api.$name;format="Camel"$StreamService;
+import $package$.api.$name;format="Camel"$Service;
+import $package$stream.api.$name;format="Camel"$StreamService;
 
 /**
  * The module that binds the $name;format="Camel"$StreamService so that it can be served.

--- a/$name__norm$-stream-impl/src/main/java/$package$stream/impl/$name__Camel$StreamServiceImpl.java
+++ b/$name__norm$-stream-impl/src/main/java/$package$stream/impl/$name__Camel$StreamServiceImpl.java
@@ -1,13 +1,13 @@
 /*
  * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
  */
-package $organization$.$name;format="camel"$stream.impl;
+package $package$stream.impl;
 
 import akka.NotUsed;
 import akka.stream.javadsl.Source;
 import com.lightbend.lagom.javadsl.api.ServiceCall;
-import $organization$.$name;format="camel"$.api.$name;format="Camel"$Service;
-import $organization$.$name;format="camel"$stream.api.$name;format="Camel"$StreamService;
+import $package$.api.$name;format="Camel"$Service;
+import $package$stream.api.$name;format="Camel"$StreamService;
 
 import javax.inject.Inject;
 

--- a/$name__norm$-stream-impl/src/main/resources/application.conf
+++ b/$name__norm$-stream-impl/src/main/resources/application.conf
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
 #
-play.modules.enabled += $organization$.$name;format="camel"$stream.impl.$name;format="Camel"$StreamModule
+play.modules.enabled += $package$stream.impl.$name;format="Camel"$StreamModule

--- a/default.properties
+++ b/default.properties
@@ -2,3 +2,4 @@ name = Hello
 organization = com.example
 version = 1.0-SNAPSHOT
 lagom_version = 1.3.1
+package = $organization$.$name;format="lower,word"$


### PR DESCRIPTION
Fixes #4 
- Use `lower` and `word` format for package names
- Path formatter for directories only allow one format, this can be solved with the [following way](https://github.com/foundweekends/giter8/pull/240#issuecomment-268843582)
