### PR TITLE
Update Lagom to 1.3.6

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,5 +1,5 @@
 name = Hello
 organization = com.example
 version = 1.0-SNAPSHOT
-lagom_version = 1.3.5
+lagom_version = 1.3.6
 package = $organization$.$name;format="lower,word"$


### PR DESCRIPTION
Note that there is now a deprecation warning, fixed in #14.

Once this is merged, #14 should be rebased and merged.