### PR TITLE
Add test/resources/logback.xml

### DIFF
--- a/src/main/g8/$name__norm$-impl/src/test/resources/logback.xml
+++ b/src/main/g8/$name__norm$-impl/src/test/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.apache.cassandra" level="ERROR" />
+    <logger name="com.datastax.driver" level="WARN" />
+
+    <logger name="akka" level="WARN" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
This suppressed excessively verbose log output when running `sbt test`.

Copied from the Scala equivalent: https://github.com/lagom/lagom-scala.g8/blob/master/src/main/g8/%24name__norm%24-impl/src/test/resources/logback.xml

Both are based on the old logging format. We can consider updating these to the newer one as a separate exercise.

Fixes #19.