### PR TITLE
Clean up the lagom-java.g8 template

### DIFF
--- a/src/main/g8/$name__norm$-api/src/main/java/$package$/api/$name__Camel$Event.java
+++ b/src/main/g8/$name__norm$-api/src/main/java/$package$/api/$name__Camel$Event.java
@@ -1,6 +1,3 @@
-/*
- * 
- */
 package $package$.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -11,21 +8,20 @@ import lombok.Value;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
-    @JsonSubTypes.Type(value = $name;format="Camel"$Event.GreetingMessageChanged.class, name = "greeting-message-changed")
+        @JsonSubTypes.Type(value = $name;format="Camel"$Event.GreetingMessageChanged.class, name = "greeting-message-changed")
 })
 public interface $name;format="Camel"$Event {
+    String getName();
 
-  String getName();
+    @Value
+    final class GreetingMessageChanged implements $name;format="Camel"$Event {
+        public final String name;
+        public final String message;
 
-  @Value
-  final class GreetingMessageChanged implements $name;format="Camel"$Event {
-    public final String name;
-    public final String message;
-
-    @JsonCreator
-    public GreetingMessageChanged(String name, String message) {
-      this.name = Preconditions.checkNotNull(name, "name");
-      this.message = Preconditions.checkNotNull(message, "message");
+        @JsonCreator
+        public GreetingMessageChanged(String name, String message) {
+            this.name = Preconditions.checkNotNull(name, "name");
+            this.message = Preconditions.checkNotNull(message, "message");
+        }
     }
-  }
 }

--- a/src/main/g8/$name__norm$-api/src/main/java/$package$/api/$name__Camel$Service.java
+++ b/src/main/g8/$name__norm$-api/src/main/java/$package$/api/$name__Camel$Service.java
@@ -48,7 +48,7 @@ public interface $name;format="Camel"$Service extends Service {
                                 // go to the same partition (and hence are delivered in order with respect
                                 // to that user), we configure a partition key strategy that extracts the
                                 // name as the partition key.
-                                .withProperty(KafkaProperties.partitionKeyStrategy(), HelloEvent::getName)
+                                .withProperty(KafkaProperties.partitionKeyStrategy(), $name;format="Camel"$Event::getName)
                 )
                 .withAutoAcl(true);
     }

--- a/src/main/g8/$name__norm$-api/src/main/java/$package$/api/$name__Camel$Service.java
+++ b/src/main/g8/$name__norm$-api/src/main/java/$package$/api/$name__Camel$Service.java
@@ -1,11 +1,4 @@
-/*
- * 
- */
 package $package$.api;
-
-import static com.lightbend.lagom.javadsl.api.Service.named;
-import static com.lightbend.lagom.javadsl.api.Service.pathCall;
-import static com.lightbend.lagom.javadsl.api.Service.topic;
 
 import akka.Done;
 import akka.NotUsed;
@@ -15,6 +8,8 @@ import com.lightbend.lagom.javadsl.api.ServiceCall;
 import com.lightbend.lagom.javadsl.api.broker.Topic;
 import com.lightbend.lagom.javadsl.api.broker.kafka.KafkaProperties;
 
+import static com.lightbend.lagom.javadsl.api.Service.*;
+
 /**
  * The $name;format="camel"$ service interface.
  * <p>
@@ -22,38 +17,39 @@ import com.lightbend.lagom.javadsl.api.broker.kafka.KafkaProperties;
  * consume the $name;format="Camel"$Service.
  */
 public interface $name;format="Camel"$Service extends Service {
+    /**
+     * Example:
+     * curl http://localhost:9000/api/hello/Alice
+     */
+    ServiceCall<NotUsed, String> hello(String id);
 
-  /**
-   * Example: curl http://localhost:9000/api/hello/Alice
-   */
-  ServiceCall<NotUsed, String> hello(String id);
+    /**
+     * Example:
+     * curl -H "Content-Type: application/json" -X POST -d '{"message": "Hi"}' http://localhost:9000/api/hello/Alice
+     */
+    ServiceCall<GreetingMessage, Done> useGreeting(String id);
 
-  /**
-   * Example: curl -H "Content-Type: application/json" -X POST -d '{"message":
-   * "Hi"}' http://localhost:9000/api/hello/Alice
-   */
-  ServiceCall<GreetingMessage, Done> useGreeting(String id);
+    /**
+     * This gets published to Kafka.
+     */
+    Topic<$name;format="Camel"$Event> helloEvents();
 
-  /**
-   * This gets published to Kafka.
-   */
-  Topic<$name;format="Camel"$Event> helloEvents();
-
-  @Override
-  default Descriptor descriptor() {
-    // @formatter:off
-    return named("$name;format="camel"$").withCalls(
-        pathCall("/api/hello/:id",  this::hello),
-        pathCall("/api/hello/:id", this::useGreeting)
-      ).withTopics(
-        topic("hello-events", this::helloEvents)
-          // Kafka partitions messages, messages within the same partition will
-          // be delivered in order, to ensure that all messages for the same user
-          // go to the same partition (and hence are delivered in order with respect
-          // to that user), we configure a partition key strategy that extracts the
-          // name as the partition key.
-          .withProperty(KafkaProperties.partitionKeyStrategy(), $name;format="Camel"$Event::getName)
-      ).withAutoAcl(true);
-    // @formatter:on
-  }
+    @Override
+    default Descriptor descriptor() {
+        return named("$name;format="camel"$")
+                .withCalls(
+                        pathCall("/api/hello/:id", this::hello),
+                        pathCall("/api/hello/:id", this::useGreeting)
+                )
+                .withTopics(
+                        topic("hello-events", this::helloEvents)
+                                // Kafka partitions messages, messages within the same partition will
+                                // be delivered in order, to ensure that all messages for the same user
+                                // go to the same partition (and hence are delivered in order with respect
+                                // to that user), we configure a partition key strategy that extracts the
+                                // name as the partition key.
+                                .withProperty(KafkaProperties.partitionKeyStrategy(), HelloEvent::getName)
+                )
+                .withAutoAcl(true);
+    }
 }

--- a/src/main/g8/$name__norm$-api/src/main/java/$package$/api/GreetingMessage.java
+++ b/src/main/g8/$name__norm$-api/src/main/java/$package$/api/GreetingMessage.java
@@ -1,21 +1,17 @@
 package $package$.api;
 
-import javax.annotation.Nullable;
-import lombok.Value;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import lombok.Value;
 
 @Value
 @JsonDeserialize
 public final class GreetingMessage {
+    public final String message;
 
-  public final String message;
-
-  @JsonCreator
-  public GreetingMessage(String message) {
-    this.message = Preconditions.checkNotNull(message, "message");
-  }
+    @JsonCreator
+    public GreetingMessage(String message) {
+        this.message = Preconditions.checkNotNull(message, "message");
+    }
 }

--- a/src/main/g8/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$Command.java
+++ b/src/main/g8/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$Command.java
@@ -1,62 +1,55 @@
-/*
- * 
- */
 package $package$.impl;
 
-import lombok.Value;
-
+import akka.Done;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Preconditions;
 import com.lightbend.lagom.javadsl.persistence.PersistentEntity;
 import com.lightbend.lagom.serialization.CompressedJsonable;
 import com.lightbend.lagom.serialization.Jsonable;
-
-import akka.Done;
+import lombok.Value;
 
 /**
  * This interface defines all the commands that the $name;format="Camel"$Entity supports.
- * 
+ * <p>
  * By convention, the commands should be inner classes of the interface, which
  * makes it simple to get a complete picture of what commands an entity
  * supports.
  */
 public interface $name;format="Camel"$Command extends Jsonable {
+    /**
+     * A command to switch the greeting message.
+     * <p>
+     * It has a reply type of {@link akka.Done}, which is sent back to the caller
+     * when all the events emitted by this command are successfully persisted.
+     */
+    @SuppressWarnings("serial")
+    @Value
+    @JsonDeserialize
+    final class UseGreetingMessage implements $name;format="Camel"$Command, CompressedJsonable, PersistentEntity.ReplyType<Done> {
+        public final String message;
 
-  /**
-   * A command to switch the greeting message.
-   * <p>
-   * It has a reply type of {@link akka.Done}, which is sent back to the caller
-   * when all the events emitted by this command are successfully persisted.
-   */
-  @SuppressWarnings("serial")
-  @Value
-  @JsonDeserialize
-  final class UseGreetingMessage implements $name;format="Camel"$Command, CompressedJsonable, PersistentEntity.ReplyType<Done> {
-    public final String message;
-
-    @JsonCreator
-    public UseGreetingMessage(String message) {
-      this.message = Preconditions.checkNotNull(message, "message");
+        @JsonCreator
+        UseGreetingMessage(String message) {
+            this.message = Preconditions.checkNotNull(message, "message");
+        }
     }
-  }
 
-  /**
-   * A command to say hello to someone using the current greeting message.
-   * <p>
-   * The reply type is String, and will contain the message to say to that
-   * person.
-   */
-  @SuppressWarnings("serial")
-  @Value
-  @JsonDeserialize
-  final class Hello implements $name;format="Camel"$Command, PersistentEntity.ReplyType<String> {
-    public final String name;
+    /**
+     * A command to say hello to someone using the current greeting message.
+     * <p>
+     * The reply type is String, and will contain the message to say to that
+     * person.
+     */
+    @SuppressWarnings("serial")
+    @Value
+    @JsonDeserialize
+    final class Hello implements $name;format="Camel"$Command, PersistentEntity.ReplyType<String> {
+        public final String name;
 
-    @JsonCreator
-    public Hello(String name) {
-      this.name = Preconditions.checkNotNull(name, "name");
+        @JsonCreator
+        Hello(String name) {
+            this.name = Preconditions.checkNotNull(name, "name");
+        }
     }
-  }
-
 }

--- a/src/main/g8/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$Entity.java
+++ b/src/main/g8/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$Entity.java
@@ -1,14 +1,11 @@
-/*
- * 
- */
 package $package$.impl;
+
+import akka.Done;
+import com.lightbend.lagom.javadsl.persistence.PersistentEntity;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import com.lightbend.lagom.javadsl.persistence.PersistentEntity;
-
-import akka.Done;
 import $package$.impl.$name;format="Camel"$Command.Hello;
 import $package$.impl.$name;format="Camel"$Command.UseGreetingMessage;
 import $package$.impl.$name;format="Camel"$Event.GreetingMessageChanged;
@@ -33,57 +30,58 @@ import $package$.impl.$name;format="Camel"$Event.GreetingMessageChanged;
  * which is emitted when a {@link UseGreetingMessage} command is received.
  */
 public class $name;format="Camel"$Entity extends PersistentEntity<$name;format="Camel"$Command, $name;format="Camel"$Event, $name;format="Camel"$State> {
-
-  /**
-   * An entity can define different behaviours for different states, but it will
-   * always start with an initial behaviour. This entity only has one behaviour.
-   */
-  @Override
-  public Behavior initialBehavior(Optional<$name;format="Camel"$State> snapshotState) {
-
-    /*
-     * Behaviour is defined using a behaviour builder. The behaviour builder
-     * starts with a state, if this entity supports snapshotting (an
-     * optimisation that allows the state itself to be persisted to combine many
-     * events into one), then the passed in snapshotState may have a value that
-     * can be used.
-     *
-     * Otherwise, the default state is to use the Hello greeting.
+    /**
+     * An entity can define different behaviours for different states, but it will
+     * always start with an initial behaviour. This entity only has one behaviour.
      */
-    BehaviorBuilder b = newBehaviorBuilder(
-        snapshotState.orElse(new $name;format="Camel"$State("Hello", LocalDateTime.now().toString())));
+    @Override
+    public Behavior initialBehavior(Optional<$name;format="Camel"$State> snapshotState) {
+        /*
+         * Behaviour is defined using a behaviour builder. The behaviour builder
+         * starts with a state, if this entity supports snapshotting (an
+         * optimisation that allows the state itself to be persisted to combine many
+         * events into one), then the passed in snapshotState may have a value that
+         * can be used.
+         *
+         * Otherwise, the default state is to use the Hello greeting.
+         */
+        BehaviorBuilder b = newBehaviorBuilder(
+                snapshotState.orElse(new $name;format="Camel"$State("Hello", LocalDateTime.now().toString()))
+        );
 
-    /*
-     * Command handler for the UseGreetingMessage command.
-     */
-    b.setCommandHandler(UseGreetingMessage.class, (cmd, ctx) ->
-    // In response to this command, we want to first persist it as a
-    // GreetingMessageChanged event
-    ctx.thenPersist(new GreetingMessageChanged(entityId(), cmd.message),
-        // Then once the event is successfully persisted, we respond with done.
-        evt -> ctx.reply(Done.getInstance())));
+        /*
+         * Command handler for the UseGreetingMessage command.
+         */
+        b.setCommandHandler(UseGreetingMessage.class, (cmd, ctx) ->
+                // In response to this command, we want to first persist it as a
+                // GreetingMessageChanged event
+                ctx.thenPersist(new GreetingMessageChanged(entityId(), cmd.message),
+                        // Then once the event is successfully persisted, we respond with done.
+                        evt -> ctx.reply(Done.getInstance())
+                )
+        );
 
-    /*
-     * Event handler for the GreetingMessageChanged event.
-     */
-    b.setEventHandler(GreetingMessageChanged.class,
-        // We simply update the current state to use the greeting message from
-        // the event.
-        evt -> new $name;format="Camel"$State(evt.message, LocalDateTime.now().toString()));
+        /*
+         * Event handler for the GreetingMessageChanged event.
+         */
+        b.setEventHandler(GreetingMessageChanged.class,
+                // We simply update the current state to use the greeting message from
+                // the event.
+                evt -> new $name;format="Camel"$State(evt.message, LocalDateTime.now().toString())
+        );
 
-    /*
-     * Command handler for the Hello command.
-     */
-    b.setReadOnlyCommandHandler(Hello.class,
-        // Get the greeting from the current state, and prepend it to the name
-        // that we're sending
-        // a greeting to, and reply with that message.
-        (cmd, ctx) -> ctx.reply(state().message + ", " + cmd.name + "!"));
+        /*
+         * Command handler for the Hello command.
+         */
+        b.setReadOnlyCommandHandler(Hello.class,
+                // Get the greeting from the current state, and prepend it to the name
+                // that we're sending a greeting to, and reply with that message.
+                (cmd, ctx) -> ctx.reply(state().message + ", " + cmd.name + "!")
+        );
 
-    /*
-     * We've defined all our behaviour, so build and return it.
-     */
-    return b.build();
-  }
-
+        /*
+         * We've defined all our behaviour, so build and return it.
+         */
+        return b.build();
+    }
 }

--- a/src/main/g8/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$Event.java
+++ b/src/main/g8/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$Event.java
@@ -1,18 +1,14 @@
-/*
- * 
- */
 package $package$.impl;
-
-import com.lightbend.lagom.javadsl.persistence.AggregateEvent;
-import com.lightbend.lagom.javadsl.persistence.AggregateEventShards;
-import com.lightbend.lagom.javadsl.persistence.AggregateEventTag;
-import com.lightbend.lagom.javadsl.persistence.AggregateEventTagger;
-import lombok.Value;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Preconditions;
+import com.lightbend.lagom.javadsl.persistence.AggregateEvent;
+import com.lightbend.lagom.javadsl.persistence.AggregateEventShards;
+import com.lightbend.lagom.javadsl.persistence.AggregateEventTag;
+import com.lightbend.lagom.javadsl.persistence.AggregateEventTagger;
 import com.lightbend.lagom.serialization.Jsonable;
+import lombok.Value;
 
 /**
  * This interface defines all the events that the $name;format="Camel"$Entity supports.
@@ -21,34 +17,33 @@ import com.lightbend.lagom.serialization.Jsonable;
  * makes it simple to get a complete picture of what events an entity has.
  */
 public interface $name;format="Camel"$Event extends Jsonable, AggregateEvent<$name;format="Camel"$Event> {
+    /**
+     * Tags are used for getting and publishing streams of events. Each event
+     * will have this tag, and in this case, we are partitioning the tags into
+     * 4 shards, which means we can have 4 concurrent processors/publishers of
+     * events.
+     */
+    AggregateEventShards<$name;format="Camel"$Event> TAG = AggregateEventTag.sharded($name;format="Camel"$Event.class, 4);
 
-  /**
-   * Tags are used for getting and publishing streams of events. Each event
-   * will have this tag, and in this case, we are partitioning the tags into
-   * 4 shards, which means we can have 4 concurrent processors/publishers of
-   * events.
-   */
-  AggregateEventShards<$name;format="Camel"$Event> TAG = AggregateEventTag.sharded($name;format="Camel"$Event.class, 4);
+    /**
+     * An event that represents a change in greeting message.
+     */
+    @SuppressWarnings("serial")
+    @Value
+    @JsonDeserialize
+    final class GreetingMessageChanged implements $name;format="Camel"$Event {
+        public final String name;
+        public final String message;
 
-  /**
-   * An event that represents a change in greeting message.
-   */
-  @SuppressWarnings("serial")
-  @Value
-  @JsonDeserialize
-  final class GreetingMessageChanged implements $name;format="Camel"$Event {
-	public final String name;
-    public final String message;
-
-    @JsonCreator
-    public GreetingMessageChanged(String name, String message) {
-      this.name = Preconditions.checkNotNull(name, "name");
-      this.message = Preconditions.checkNotNull(message, "message");
+        @JsonCreator
+        GreetingMessageChanged(String name, String message) {
+            this.name = Preconditions.checkNotNull(name, "name");
+            this.message = Preconditions.checkNotNull(message, "message");
+        }
     }
-  }
 
-  @Override
-  default AggregateEventTagger<$name;format="Camel"$Event> aggregateTag() {
-    return TAG;
-  }
+    @Override
+    default AggregateEventTagger<$name;format="Camel"$Event> aggregateTag() {
+        return TAG;
+    }
 }

--- a/src/main/g8/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$Module.java
+++ b/src/main/g8/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$Module.java
@@ -1,18 +1,16 @@
-/*
- * 
- */
 package $package$.impl;
 
 import com.google.inject.AbstractModule;
 import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport;
+
 import $package$.api.$name;format="Camel"$Service;
 
 /**
  * The module that binds the $name;format="Camel"$Service so that it can be served.
  */
 public class $name;format="Camel"$Module extends AbstractModule implements ServiceGuiceSupport {
-  @Override
-  protected void configure() {
-    bindService($name;format="Camel"$Service.class, $name;format="Camel"$ServiceImpl.class);
-  }
+    @Override
+    protected void configure() {
+        bindService($name;format="Camel"$Service.class, $name;format="Camel"$ServiceImpl.class);
+    }
 }

--- a/src/main/g8/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$ServiceImpl.java
+++ b/src/main/g8/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$ServiceImpl.java
@@ -1,6 +1,3 @@
-/*
- * 
- */
 package $package$.impl;
 
 import akka.Done;
@@ -22,63 +19,59 @@ import $package$.impl.$name;format="Camel"$Command.*;
  * Implementation of the $name;format="Camel"$Service.
  */
 public class $name;format="Camel"$ServiceImpl implements $name;format="Camel"$Service {
+    private final PersistentEntityRegistry persistentEntityRegistry;
 
-  private final PersistentEntityRegistry persistentEntityRegistry;
+    @Inject
+    public $name;format="Camel"$ServiceImpl(PersistentEntityRegistry persistentEntityRegistry) {
+        this.persistentEntityRegistry = persistentEntityRegistry;
+        persistentEntityRegistry.register($name;format="Camel"$Entity.class);
+    }
 
-  @Inject
-  public $name;format="Camel"$ServiceImpl(PersistentEntityRegistry persistentEntityRegistry) {
-    this.persistentEntityRegistry = persistentEntityRegistry;
-    persistentEntityRegistry.register($name;format="Camel"$Entity.class);
-  }
+    @Override
+    public ServiceCall<NotUsed, String> hello(String id) {
+        return request -> {
+            // Look up the hello world entity for the given ID.
+            PersistentEntityRef<$name;format="Camel"$Command> ref = persistentEntityRegistry.refFor($name;format="Camel"$Entity.class, id);
+            // Ask the entity the Hello command.
+            return ref.ask(new Hello(id));
+        };
+    }
 
-  @Override
-  public ServiceCall<NotUsed, String> hello(String id) {
-    return request -> {
-      // Look up the hello world entity for the given ID.
-      PersistentEntityRef<$name;format="Camel"$Command> ref = persistentEntityRegistry.refFor($name;format="Camel"$Entity.class, id);
-      // Ask the entity the Hello command.
-      return ref.ask(new Hello(id));
-    };
-  }
+    @Override
+    public ServiceCall<GreetingMessage, Done> useGreeting(String id) {
+        return request -> {
+            // Look up the hello world entity for the given ID.
+            PersistentEntityRef<$name;format="Camel"$Command> ref = persistentEntityRegistry.refFor($name;format="Camel"$Entity.class, id);
+            // Tell the entity to use the greeting message specified.
+            return ref.ask(new UseGreetingMessage(request.message));
+        };
+    }
 
-  @Override
-  public ServiceCall<GreetingMessage, Done> useGreeting(String id) {
-    return request -> {
-      // Look up the hello world entity for the given ID.
-      PersistentEntityRef<$name;format="Camel"$Command> ref = persistentEntityRegistry.refFor($name;format="Camel"$Entity.class, id);
-      // Tell the entity to use the greeting message specified.
-      return ref.ask(new UseGreetingMessage(request.message));
-    };
+    @Override
+    public Topic<$package$.api.$name;format="Camel"$Event> helloEvents() {
+        // We want to publish all the shards of the hello event
+        return TopicProducer.taggedStreamWithOffset($name;format="Camel"$Event.TAG.allTags(), (tag, offset) ->
+                // Load the event stream for the passed in shard tag
+                persistentEntityRegistry.eventStream(tag, offset).map(eventAndOffset -> {
+                    // Now we want to convert from the persisted event to the published event.
+                    // Although these two events are currently identical, in future they may
+                    // change and need to evolve separately, by separating them now we save
+                    // a lot of potential trouble in future.
+                    $package$.api.$name;format="Camel"$Event eventToPublish;
 
-  }
+                    if (eventAndOffset.first() instanceof $name;format="Camel"$Event.GreetingMessageChanged) {
+                        $name;format="Camel"$Event.GreetingMessageChanged messageChanged = ($name;format="Camel"$Event.GreetingMessageChanged) eventAndOffset.first();
+                        eventToPublish = new $package$.api.$name;format="Camel"$Event.GreetingMessageChanged(
+                                messageChanged.getName(), messageChanged.getMessage()
+                        );
+                    } else {
+                        throw new IllegalArgumentException("Unknown event: " + eventAndOffset.first());
+                    }
 
-  @Override
-  public Topic<$package$.api.$name;format="Camel"$Event> helloEvents() {
-    // We want to publish all the shards of the hello event
-    return TopicProducer.taggedStreamWithOffset($name;format="Camel"$Event.TAG.allTags(), (tag, offset) ->
-
-      // Load the event stream for the passed in shard tag
-      persistentEntityRegistry.eventStream(tag, offset).map(eventAndOffset -> {
-
-        // Now we want to convert from the persisted event to the published event.
-        // Although these two events are currently identical, in future they may
-        // change and need to evolve separately, by separating them now we save
-        // a lot of potential trouble in future.
-        $package$.api.$name;format="Camel"$Event eventToPublish;
-
-        if (eventAndOffset.first() instanceof $name;format="Camel"$Event.GreetingMessageChanged) {
-          $name;format="Camel"$Event.GreetingMessageChanged messageChanged = ($name;format="Camel"$Event.GreetingMessageChanged) eventAndOffset.first();
-          eventToPublish = new $package$.api.$name;format="Camel"$Event.GreetingMessageChanged(
-            messageChanged.getName(), messageChanged.getMessage()
-          );
-        } else {
-          throw new IllegalArgumentException("Unknown event: " + eventAndOffset.first());
-        }
-
-        // We return a pair of the translated event, and its offset, so that
-        // Lagom can track which offsets have been published.
-        return Pair.create(eventToPublish, eventAndOffset.second());
-      })
-    );
-  }
+                    // We return a pair of the translated event, and its offset, so that
+                    // Lagom can track which offsets have been published.
+                    return Pair.create(eventToPublish, eventAndOffset.second());
+                })
+        );
+    }
 }

--- a/src/main/g8/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$State.java
+++ b/src/main/g8/$name__norm$-impl/src/main/java/$package$/impl/$name__Camel$State.java
@@ -1,14 +1,10 @@
-/*
- * 
- */
 package $package$.impl;
-
-import lombok.Value;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Preconditions;
 import com.lightbend.lagom.serialization.CompressedJsonable;
+import lombok.Value;
 
 /**
  * The state for the {@link $name;format="Camel"$Entity} entity.
@@ -17,13 +13,12 @@ import com.lightbend.lagom.serialization.CompressedJsonable;
 @Value
 @JsonDeserialize
 public final class $name;format="Camel"$State implements CompressedJsonable {
+    public final String message;
+    public final String timestamp;
 
-  public final String message;
-  public final String timestamp;
-
-  @JsonCreator
-  public $name;format="Camel"$State(String message, String timestamp) {
-    this.message = Preconditions.checkNotNull(message, "message");
-    this.timestamp = Preconditions.checkNotNull(timestamp, "timestamp");
-  }
+    @JsonCreator
+    $name;format="Camel"$State(String message, String timestamp) {
+        this.message = Preconditions.checkNotNull(message, "message");
+        this.timestamp = Preconditions.checkNotNull(timestamp, "timestamp");
+    }
 }

--- a/src/main/g8/$name__norm$-impl/src/main/resources/application.conf
+++ b/src/main/g8/$name__norm$-impl/src/main/resources/application.conf
@@ -1,6 +1,3 @@
-#
-# 
-#
 play.modules.enabled += $package$.impl.$name;format="Camel"$Module
 
 $name;format="norm"$.cassandra.keyspace = $name;format="lower,snake,word"$

--- a/src/main/g8/$name__norm$-impl/src/test/java/$package$/impl/$name__Camel$EntityTest.java
+++ b/src/main/g8/$name__norm$-impl/src/test/java/$package$/impl/$name__Camel$EntityTest.java
@@ -11,8 +11,9 @@ import org.junit.Test;
 
 import java.util.Collections;
 
-import com.lightbend.lagom.javadsl.testkit.PersistentEntityTestDriver;
-import com.lightbend.lagom.javadsl.testkit.PersistentEntityTestDriver.Outcome;
+import $package$.impl.$name;format="Camel"$Command.Hello;
+import $package$.impl.$name;format="Camel"$Command.UseGreetingMessage;
+import $package$.impl.$name;format="Camel"$Event.GreetingMessageChanged;
 
 import static org.junit.Assert.assertEquals;
 

--- a/src/main/g8/$name__norm$-impl/src/test/java/$package$/impl/$name__Camel$EntityTest.java
+++ b/src/main/g8/$name__norm$-impl/src/test/java/$package$/impl/$name__Camel$EntityTest.java
@@ -1,57 +1,52 @@
 package $package$.impl;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Collections;
-import java.util.Optional;
-
+import akka.Done;
+import akka.actor.ActorSystem;
+import akka.testkit.javadsl.TestKit;
+import com.lightbend.lagom.javadsl.testkit.PersistentEntityTestDriver;
+import com.lightbend.lagom.javadsl.testkit.PersistentEntityTestDriver.Outcome;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import com.lightbend.lagom.javadsl.testkit.PersistentEntityTestDriver;
 import com.lightbend.lagom.javadsl.testkit.PersistentEntityTestDriver.Outcome;
 
-import akka.Done;
-import akka.actor.ActorSystem;
-import akka.testkit.JavaTestKit;
-import $package$.impl.$name;format="Camel"$Command.Hello;
-import $package$.impl.$name;format="Camel"$Command.UseGreetingMessage;
-import $package$.impl.$name;format="Camel"$Event.GreetingMessageChanged;
+import static org.junit.Assert.assertEquals;
 
 public class $name;format="Camel"$EntityTest {
+    private static ActorSystem system;
 
-  static ActorSystem system;
+    @BeforeClass
+    public static void setup() {
+        system = ActorSystem.create("$name;format="Camel"$EntityTest");
+    }
 
-  @BeforeClass
-  public static void setup() {
-    system = ActorSystem.create("$name;format="Camel"$EntityTest");
-  }
+    @AfterClass
+    public static void teardown() {
+        TestKit.shutdownActorSystem(system);
+        system = null;
+    }
 
-  @AfterClass
-  public static void teardown() {
-    JavaTestKit.shutdownActorSystem(system);
-    system = null;
-  }
+    @Test
+    public void test$name;format="Camel"$Entity() {
+        PersistentEntityTestDriver<$name;format="Camel"$Command, $name;format="Camel"$Event, $name;format="Camel"$State> driver = new PersistentEntityTestDriver<>(system,
+                new $name;format="Camel"$Entity(), "world-1");
 
-  @Test
-  public void test$name;format="Camel"$Entity() {
-    PersistentEntityTestDriver<$name;format="Camel"$Command, $name;format="Camel"$Event, $name;format="Camel"$State> driver = new PersistentEntityTestDriver<>(system,
-        new $name;format="Camel"$Entity(), "world-1");
+        Outcome<$name;format="Camel"$Event, $name;format="Camel"$State> outcome1 = driver.run(new Hello("Alice"));
+        assertEquals("Hello, Alice!", outcome1.getReplies().get(0));
+        assertEquals(Collections.emptyList(), outcome1.issues());
 
-    Outcome<$name;format="Camel"$Event, $name;format="Camel"$State> outcome1 = driver.run(new Hello("Alice"));
-    assertEquals("Hello, Alice!", outcome1.getReplies().get(0));
-    assertEquals(Collections.emptyList(), outcome1.issues());
-
-    Outcome<$name;format="Camel"$Event, $name;format="Camel"$State> outcome2 = driver.run(new UseGreetingMessage("Hi"),
-        new Hello("Bob"));
-    assertEquals(1, outcome2.events().size());
-    assertEquals(new GreetingMessageChanged("world-1", "Hi"), outcome2.events().get(0));
-    assertEquals("Hi", outcome2.state().message);
-    assertEquals(Done.getInstance(), outcome2.getReplies().get(0));
-    assertEquals("Hi, Bob!", outcome2.getReplies().get(1));
-    assertEquals(2, outcome2.getReplies().size());
-    assertEquals(Collections.emptyList(), outcome2.issues());
-  }
-
+        Outcome<$name;format="Camel"$Event, $name;format="Camel"$State> outcome2 = driver.run(new UseGreetingMessage("Hi"),
+                new Hello("Bob"));
+        assertEquals(1, outcome2.events().size());
+        assertEquals(new GreetingMessageChanged("world-1", "Hi"), outcome2.events().get(0));
+        assertEquals("Hi", outcome2.state().message);
+        assertEquals(Done.getInstance(), outcome2.getReplies().get(0));
+        assertEquals("Hi, Bob!", outcome2.getReplies().get(1));
+        assertEquals(2, outcome2.getReplies().size());
+        assertEquals(Collections.emptyList(), outcome2.issues());
+    }
 }

--- a/src/main/g8/$name__norm$-impl/src/test/java/$package$/impl/$name__Camel$ServiceTest.java
+++ b/src/main/g8/$name__norm$-impl/src/test/java/$package$/impl/$name__Camel$ServiceTest.java
@@ -1,35 +1,30 @@
-/*
- * 
- */
 package $package$.impl;
-
-import static com.lightbend.lagom.javadsl.testkit.ServiceTest.defaultSetup;
-import static com.lightbend.lagom.javadsl.testkit.ServiceTest.withServer;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
 import $package$.api.GreetingMessage;
 import $package$.api.$name;format="Camel"$Service;
 
+import static com.lightbend.lagom.javadsl.testkit.ServiceTest.defaultSetup;
+import static com.lightbend.lagom.javadsl.testkit.ServiceTest.withServer;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+
 public class $name;format="Camel"$ServiceTest {
+    @Test
+    public void shouldStorePersonalizedGreeting() {
+        withServer(defaultSetup().withCassandra(), server -> {
+            $name;format="Camel"$Service service = server.client($name;format="Camel"$Service.class);
 
-  @Test
-  public void shouldStorePersonalizedGreeting() throws Exception {
-    withServer(defaultSetup().withCassandra(), server -> {
-      $name;format="Camel"$Service service = server.client($name;format="Camel"$Service.class);
+            String msg1 = service.hello("Alice").invoke().toCompletableFuture().get(5, SECONDS);
+            assertEquals("Hello, Alice!", msg1); // default greeting
 
-      String msg1 = service.hello("Alice").invoke().toCompletableFuture().get(5, SECONDS);
-      assertEquals("Hello, Alice!", msg1); // default greeting
+            service.useGreeting("Alice").invoke(new GreetingMessage("Hi")).toCompletableFuture().get(5, SECONDS);
+            String msg2 = service.hello("Alice").invoke().toCompletableFuture().get(5, SECONDS);
+            assertEquals("Hi, Alice!", msg2);
 
-      service.useGreeting("Alice").invoke(new GreetingMessage("Hi")).toCompletableFuture().get(5, SECONDS);
-      String msg2 = service.hello("Alice").invoke().toCompletableFuture().get(5, SECONDS);
-      assertEquals("Hi, Alice!", msg2);
-
-      String msg3 = service.hello("Bob").invoke().toCompletableFuture().get(5, SECONDS);
-      assertEquals("Hello, Bob!", msg3); // default greeting
-    });
-  }
-
+            String msg3 = service.hello("Bob").invoke().toCompletableFuture().get(5, SECONDS);
+            assertEquals("Hello, Bob!", msg3); // default greeting
+        });
+    }
 }

--- a/src/main/g8/$name__norm$-impl/src/test/resources/logback.xml
+++ b/src/main/g8/$name__norm$-impl/src/test/resources/logback.xml
@@ -3,7 +3,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%date{ISO8601} %-5level %logger - %msg%n</pattern>
+            <pattern>%date{"HH:mm:ss.SSS"} %coloredLevel %logger - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/src/main/g8/$name__norm$-impl/src/test/resources/logback.xml
+++ b/src/main/g8/$name__norm$-impl/src/test/resources/logback.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
+    <conversionRule conversionWord="coloredLevel" converterClass="com.lightbend.lagom.internal.logback.ColoredLevel" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%date{"HH:mm:ss.SSS"} %coloredLevel %logger - %msg%n</pattern>

--- a/src/main/g8/$name__norm$-stream-api/src/main/java/$package$stream/api/$name__Camel$StreamService.java
+++ b/src/main/g8/$name__norm$-stream-api/src/main/java/$package$stream/api/$name__Camel$StreamService.java
@@ -1,16 +1,13 @@
-/*
- * 
- */
 package $package$stream.api;
-
-import static com.lightbend.lagom.javadsl.api.Service.named;
-import static com.lightbend.lagom.javadsl.api.Service.namedCall;
 
 import akka.NotUsed;
 import akka.stream.javadsl.Source;
 import com.lightbend.lagom.javadsl.api.Descriptor;
 import com.lightbend.lagom.javadsl.api.Service;
 import com.lightbend.lagom.javadsl.api.ServiceCall;
+
+import static com.lightbend.lagom.javadsl.api.Service.named;
+import static com.lightbend.lagom.javadsl.api.Service.namedCall;
 
 /**
  * The $name$ stream interface.
@@ -19,28 +16,28 @@ import com.lightbend.lagom.javadsl.api.ServiceCall;
  * consume the $name;format="Camel"$StreamService service.
  */
 public interface $name;format="Camel"$StreamService extends Service {
+    /**
+     * This stream is implemented by asking the hello service directly to say
+     * hello to each passed in name. It requires the hello service to be up
+     * and running to function.
+     */
+    ServiceCall<Source<String, NotUsed>, Source<String, NotUsed>> directStream();
 
-  /**
-   * This stream is implemented by asking the hello service directly to say
-   * hello to each passed in name. It requires the hello service to be up
-   * and running to function.
-   */
-  ServiceCall<Source<String, NotUsed>, Source<String, NotUsed>> directStream();
+    /**
+     * This stream is implemented autonomously, it uses its own store, populated
+     * by subscribing to the events published by the hello service, to say hello
+     * to each passed in name. It can function even when the hello service is
+     * down.
+     */
+    ServiceCall<Source<String, NotUsed>, Source<String, NotUsed>> autonomousStream();
 
-  /**
-   * This stream is implemented autonomously, it uses its own store, populated
-   * by subscribing to the events published by the hello service, to say hello
-   * to each passed in name. It can function even when the hello service is
-   * down.
-   */
-  ServiceCall<Source<String, NotUsed>, Source<String, NotUsed>> autonomousStream();
-
-  @Override
-  default Descriptor descriptor() {
-    return named("$name;format="norm"$-stream")
-        .withCalls(
-            namedCall("direct-stream", this::directStream),
-            namedCall("auto-stream", this::autonomousStream)
-        ).withAutoAcl(true);
-  }
+    @Override
+    default Descriptor descriptor() {
+        return named("$name;format="norm"$-stream")
+                .withCalls(
+                        namedCall("direct-stream", this::directStream),
+                        namedCall("auto-stream", this::autonomousStream)
+                )
+                .withAutoAcl(true);
+    }
 }

--- a/src/main/g8/$name__norm$-stream-impl/src/main/java/$package$stream/impl/$name__Camel$StreamModule.java
+++ b/src/main/g8/$name__norm$-stream-impl/src/main/java/$package$stream/impl/$name__Camel$StreamModule.java
@@ -1,10 +1,8 @@
-/*
- * 
- */
 package $package$stream.impl;
 
 import com.google.inject.AbstractModule;
 import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport;
+
 import $package$.api.$name;format="Camel"$Service;
 import $package$stream.api.$name;format="Camel"$StreamService;
 
@@ -12,13 +10,13 @@ import $package$stream.api.$name;format="Camel"$StreamService;
  * The module that binds the $name;format="Camel"$StreamService so that it can be served.
  */
 public class $name;format="Camel"$StreamModule extends AbstractModule implements ServiceGuiceSupport {
-  @Override
-  protected void configure() {
-    // Bind the $name;format="Camel"$StreamService service
-    bindService($name;format="Camel"$StreamService.class, $name;format="Camel"$StreamServiceImpl.class);
-    // Bind the $name;format="Camel"$Service client
-    bindClient($name;format="Camel"$Service.class);
-    // Bind the subscriber eagerly to ensure it starts up
-    bind($name;format="Camel"$StreamSubscriber.class).asEagerSingleton();
-  }
+    @Override
+    protected void configure() {
+        // Bind the $name;format="Camel"$StreamService service
+        bindService($name;format="Camel"$StreamService.class, $name;format="Camel"$StreamServiceImpl.class);
+        // Bind the $name;format="Camel"$Service client
+        bindClient($name;format="Camel"$Service.class);
+        // Bind the subscriber eagerly to ensure it starts up
+        bind($name;format="Camel"$StreamSubscriber.class).asEagerSingleton();
+    }
 }

--- a/src/main/g8/$name__norm$-stream-impl/src/main/java/$package$stream/impl/$name__Camel$StreamRepository.java
+++ b/src/main/g8/$name__norm$-stream-impl/src/main/java/$package$stream/impl/$name__Camel$StreamRepository.java
@@ -1,6 +1,3 @@
-/*
- * 
- */
 package $package$stream.impl;
 
 import akka.Done;
@@ -14,39 +11,39 @@ import java.util.concurrent.CompletionStage;
 
 @Singleton
 public class $name;format="Camel"$StreamRepository {
-  private final CassandraSession uninitialisedSession;
+    private final CassandraSession uninitializedSession;
 
-  // Will return the session when the Cassandra tables have been successfully created
-  private volatile CompletableFuture<CassandraSession> initialisedSession;
+    // Will return the session when the Cassandra tables have been successfully created
+    private volatile CompletableFuture<CassandraSession> initializedSession;
 
-  @Inject
-  public $name;format="Camel"$StreamRepository(CassandraSession uninitialisedSession) {
-    this.uninitialisedSession = uninitialisedSession;
-    // Eagerly create the session
-    session();
-  }
-
-  private CompletionStage<CassandraSession> session() {
-    // If there's no initialised session, or if the initialised session future completed
-    // with an exception, then reinitialise the session and attempt to create the tables
-    if (initialisedSession == null || initialisedSession.isCompletedExceptionally()) {
-      initialisedSession = uninitialisedSession.executeCreateTable(
-          "CREATE TABLE IF NOT EXISTS greeting_message (name text PRIMARY KEY, message text)"
-      ).thenApply(done -> uninitialisedSession).toCompletableFuture();
+    @Inject
+    public $name;format="Camel"$StreamRepository(CassandraSession uninitializedSession) {
+        this.uninitializedSession = uninitializedSession;
+        // Eagerly create the session
+        session();
     }
-    return initialisedSession;
-  }
 
-  public CompletionStage<Done> updateMessage(String name, String message) {
-    return session().thenCompose(session ->
-        session.executeWrite("INSERT INTO greeting_message (name, message) VALUES (?, ?)",
-            name, message)
-    );
-  }
+    private CompletionStage<CassandraSession> session() {
+        // If there's no initialized session, or if the initialized session future completed
+        // with an exception, then reinitialize the session and attempt to create the tables
+        if (initializedSession == null || initializedSession.isCompletedExceptionally()) {
+            initializedSession = uninitializedSession.executeCreateTable(
+                    "CREATE TABLE IF NOT EXISTS greeting_message (name text PRIMARY KEY, message text)"
+            ).thenApply(done -> uninitializedSession).toCompletableFuture();
+        }
+        return initializedSession;
+    }
 
-  public CompletionStage<Optional<String>> getMessage(String name) {
-    return session().thenCompose(session ->
-        session.selectOne("SELECT message FROM greeting_message WHERE name = ?", name)
-    ).thenApply(maybeRow -> maybeRow.map(row -> row.getString("message")));
-  }
+    public CompletionStage<Done> updateMessage(String name, String message) {
+        return session().thenCompose(session ->
+                session.executeWrite("INSERT INTO greeting_message (name, message) VALUES (?, ?)",
+                        name, message)
+        );
+    }
+
+    public CompletionStage<Optional<String>> getMessage(String name) {
+        return session().thenCompose(session ->
+                session.selectOne("SELECT message FROM greeting_message WHERE name = ?", name)
+        ).thenApply(maybeRow -> maybeRow.map(row -> row.getString("message")));
+    }
 }

--- a/src/main/g8/$name__norm$-stream-impl/src/main/java/$package$stream/impl/$name__Camel$StreamServiceImpl.java
+++ b/src/main/g8/$name__norm$-stream-impl/src/main/java/$package$stream/impl/$name__Camel$StreamServiceImpl.java
@@ -1,11 +1,9 @@
-/*
- * 
- */
 package $package$stream.impl;
 
 import akka.NotUsed;
 import akka.stream.javadsl.Source;
 import com.lightbend.lagom.javadsl.api.ServiceCall;
+
 import $package$.api.$name;format="Camel"$Service;
 import $package$stream.api.$name;format="Camel"$StreamService;
 
@@ -17,28 +15,27 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
  * Implementation of the $name;format="Camel"$StreamService.
  */
 public class $name;format="Camel"$StreamServiceImpl implements $name;format="Camel"$StreamService {
+    private final $name;format="Camel"$Service $name;format="camel"$Service;
+    private final $name;format="Camel"$StreamRepository repository;
 
-  private final $name;format="Camel"$Service $name;format="camel"$Service;
-  private final $name;format="Camel"$StreamRepository repository;
+    @Inject
+    public $name;format="Camel"$StreamServiceImpl($name;format="Camel"$Service $name;format="camel"$Service, $name;format="Camel"$StreamRepository repository) {
+        this.$name;format="camel"$Service = $name;format="camel"$Service;
+        this.repository = repository;
+    }
 
-  @Inject
-  public $name;format="Camel"$StreamServiceImpl($name;format="Camel"$Service $name;format="camel"$Service, $name;format="Camel"$StreamRepository repository) {
-    this.$name;format="camel"$Service = $name;format="camel"$Service;
-    this.repository = repository;
-  }
+    @Override
+    public ServiceCall<Source<String, NotUsed>, Source<String, NotUsed>> directStream() {
+        return hellos -> completedFuture(
+                hellos.mapAsync(8, name -> $name;format="camel"$Service.hello(name).invoke()));
+    }
 
-  @Override
-  public ServiceCall<Source<String, NotUsed>, Source<String, NotUsed>> directStream() {
-    return hellos -> completedFuture(
-        hellos.mapAsync(8, name -> $name;format="camel"$Service.hello(name).invoke()));
-  }
-
-  @Override
-  public ServiceCall<Source<String, NotUsed>, Source<String, NotUsed>> autonomousStream() {
-    return hellos -> completedFuture(
-        hellos.mapAsync(8, name -> repository.getMessage(name).thenApply( message ->
-            String.format("%s, %s!", message.orElse("Hello"), name)
-        ))
-    );
-  }
+    @Override
+    public ServiceCall<Source<String, NotUsed>, Source<String, NotUsed>> autonomousStream() {
+        return hellos -> completedFuture(
+                hellos.mapAsync(8, name -> repository.getMessage(name).thenApply(message ->
+                        String.format("%s, %s!", message.orElse("Hello"), name)
+                ))
+        );
+    }
 }

--- a/src/main/g8/$name__norm$-stream-impl/src/main/java/$package$stream/impl/$name__Camel$StreamSubscriber.java
+++ b/src/main/g8/$name__norm$-stream-impl/src/main/java/$package$stream/impl/$name__Camel$StreamSubscriber.java
@@ -1,10 +1,8 @@
-/*
- * 
- */
 package $package$stream.impl;
 
 import akka.Done;
 import akka.stream.javadsl.Flow;
+
 import $package$.api.$name;format="Camel"$Event;
 import $package$.api.$name;format="Camel"$Service;
 
@@ -15,27 +13,23 @@ import java.util.concurrent.CompletableFuture;
  * This subscribes to the $name;format="Camel"$Service event stream.
  */
 public class $name;format="Camel"$StreamSubscriber {
-
-  @Inject
-  public $name;format="Camel"$StreamSubscriber($name;format="Camel"$Service $name;format="camel"$Service, $name;format="Camel"$StreamRepository repository) {
-    // Create a subscriber
-    $name;format="camel"$Service.helloEvents().subscribe()
-      // And subscribe to it with at least once processing semantics.
-      .atLeastOnce(
-        // Create a flow that emits a Done for each message it processes
-        Flow.<$name;format="Camel"$Event>create().mapAsync(1, event -> {
-
-          if (event instanceof $name;format="Camel"$Event.GreetingMessageChanged) {
-            $name;format="Camel"$Event.GreetingMessageChanged messageChanged = ($name;format="Camel"$Event.GreetingMessageChanged) event;
-            // Update the message
-            return repository.updateMessage(messageChanged.getName(), messageChanged.getMessage());
-
-          } else {
-            // Ignore all other events
-            return CompletableFuture.completedFuture(Done.getInstance());
-          }
-        })
-      );
-
-  }
+    @Inject
+    public $name;format="Camel"$StreamSubscriber($name;format="Camel"$Service $name;format="camel"$Service, $name;format="Camel"$StreamRepository repository) {
+        // Create a subscriber
+        $name;format="camel"$Service.helloEvents().subscribe()
+                // And subscribe to it with at least once processing semantics.
+                .atLeastOnce(
+                        // Create a flow that emits a Done for each message it processes
+                        Flow.<$name;format="Camel"$Event>create().mapAsync(1, event -> {
+                            if (event instanceof $name;format="Camel"$Event.GreetingMessageChanged) {
+                                $name;format="Camel"$Event.GreetingMessageChanged messageChanged = ($name;format="Camel"$Event.GreetingMessageChanged) event;
+                                // Update the message
+                                return repository.updateMessage(messageChanged.getName(), messageChanged.getMessage());
+                            } else {
+                                // Ignore all other events
+                                return CompletableFuture.completedFuture(Done.getInstance());
+                            }
+                        })
+                );
+    }
 }

--- a/src/main/g8/$name__norm$-stream-impl/src/main/resources/application.conf
+++ b/src/main/g8/$name__norm$-stream-impl/src/main/resources/application.conf
@@ -1,6 +1,3 @@
-#
-# 
-#
 play.modules.enabled += $package$stream.impl.$name;format="Camel"$StreamModule
 
 $name;format="norm"$-stream.cassandra.keyspace = $name;format="lower,snake,word"$_stream

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -23,6 +23,7 @@ lazy val `$name;format="norm"$-impl` = (project in file("$name;format="norm"$-im
     libraryDependencies ++= Seq(
       lagomJavadslPersistenceCassandra,
       lagomJavadslKafkaBroker,
+      lagomLogback,
       lagomJavadslTestKit,
       lombok
     )
@@ -45,6 +46,7 @@ lazy val `$name;format="norm"$-stream-impl` = (project in file("$name;format="no
     libraryDependencies ++= Seq(
       lagomJavadslPersistenceCassandra,
       lagomJavadslKafkaClient,
+      lagomLogback,
       lagomJavadslTestKit
     )
   )


### PR DESCRIPTION
- Fix deprecation warnings
- Remove empty header comments
- Organize imports
- Reformat to standard four-space indent
- Change a few hard-to-read line breaks and other minor formatting