### PR TITLE
Removes akka-misc  as it's not visible (no dep on lagomCluster)

### DIFF
--- a/src/main/g8/$name__norm$-stream-impl/src/main/resources/application.conf
+++ b/src/main/g8/$name__norm$-stream-impl/src/main/resources/application.conf
@@ -27,8 +27,3 @@ lagom.persistence.read-side.cassandra.keyspace = \${$name;format="norm"$-stream.
 # Prefer 'ddata' over 'persistence' to share cluster sharding state for new projects.
 # See https://doc.akka.io/docs/akka/current/cluster-sharding.html#distributed-data-vs-persistence-mode
 akka.cluster.sharding.state-store-mode = ddata
-
-# Enable the serializer for akka.Done provided in Akka 2.5.8+ to avoid the use of Java serialization.
-akka.actor.serialization-bindings {
-  "akka.Done" = akka-misc
-}


### PR DESCRIPTION
This is the `lagom-java.g8`  equivalent of https://github.com/lagom/lagom-scala.g8/commit/c6e6682329b53c77f4cf2447473c6938dee90d22.

I've only removed `akka-misc` for the moment as that's the only change required to make the sample projects run. I think, though, that `applicaiton.conf` in `hello-stream-impl`  should not have any setting that's persistence/cluster related as that project doesn't do any persistence and doesn't use any clustering.