### PR TITLE
Adds Mergify file to 1.6.x

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,28 @@
+
+pull_request_rules:
+  - name: Merge PRs that are ready
+    conditions:
+      - status-success=Travis CI - Pull Request
+      - status-success=typesafe-cla-validator
+      - "#approved-reviews-by>=1"
+      - "#review-requested=0"
+      - "#changes-requested-reviews-by=0"
+      - label!=status:block-merge
+    actions:
+      merge:
+        method: squash
+        strict: smart
+        
+  - name: Delete the PR branch after merge
+    conditions:
+      - merged
+    actions:
+      delete_head_branch: {}
+
+  - name: auto add wip
+    conditions:
+      # match a few flavours of wip
+      - title~=^(\[wip\]( |:) |\[WIP\]( |:) |wip( |:) |WIP( |:)).*
+    actions:
+      label:
+        add: ["status:block-merge"]


### PR DESCRIPTION
This is a preparation for when 1.6.x becomes the default branch.

Mergify wasn't working because it was only added to 1.4.x and not in 1.5.x. It stopped working when we made 1.5.x the default branch.

I added the file directly to 1.5.x (no PR), but I'm sending this PR so for 1.6.x so the team is aware of this change.