### PR TITLE
Make the default name the same as lagom-scala.g8

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,4 +1,4 @@
-name = Hello
+name = Hello World
 organization = com.example
 version = 1.0-SNAPSHOT
 package = $organization$.$name;format="lower,word"$


### PR DESCRIPTION
Just a minor inconsistency I noticed.

https://github.com/lagom/lagom-scala.g8/blob/1.5.x/src/main/g8/default.properties