### PR TITLE
Remove the extra serializer bindings

### DIFF
--- a/src/main/g8/$name__norm$-impl/src/main/resources/application.conf
+++ b/src/main/g8/$name__norm$-impl/src/main/resources/application.conf
@@ -27,12 +27,3 @@ lagom.persistence.read-side.cassandra.keyspace = \${$name;format="norm"$.cassand
 # Prefer 'ddata' over 'persistence' to share cluster sharding state for new projects.
 # See https://doc.akka.io/docs/akka/current/cluster-sharding.html#distributed-data-vs-persistence-mode
 akka.cluster.sharding.state-store-mode = ddata
-
-# Enable the serializer provided in Akka 2.5.8+ for akka.Done and other internal
-# messages to avoid the use of Java serialization.
-akka.actor.serialization-bindings {
-  "akka.Done"                 = akka-misc
-  "akka.NotUsed"              = akka-misc
-  "akka.actor.Address"        = akka-misc
-  "akka.remote.UniqueAddress" = akka-misc
-}

--- a/src/main/g8/$name__norm$-stream-impl/src/main/resources/application.conf
+++ b/src/main/g8/$name__norm$-stream-impl/src/main/resources/application.conf
@@ -27,12 +27,3 @@ lagom.persistence.read-side.cassandra.keyspace = \${$name;format="norm"$-stream.
 # Prefer 'ddata' over 'persistence' to share cluster sharding state for new projects.
 # See https://doc.akka.io/docs/akka/current/cluster-sharding.html#distributed-data-vs-persistence-mode
 akka.cluster.sharding.state-store-mode = ddata
-
-# Enable the serializer provided in Akka 2.5.8+ for akka.Done and other internal
-# messages to avoid the use of Java serialization.
-akka.actor.serialization-bindings {
-  "akka.Done"                 = akka-misc
-  "akka.NotUsed"              = akka-misc
-  "akka.actor.Address"        = akka-misc
-  "akka.remote.UniqueAddress" = akka-misc
-}


### PR DESCRIPTION
These are now configured by default in Lagom 1.5.3.

https://github.com/lagom/lagom/blob/1.5.3/cluster/core/src/main/resources/reference.conf#L27-L32