### PR TITLE
Remove default config settings

### DIFF
--- a/src/main/g8/$name__norm$-stream-impl/src/main/resources/application.conf
+++ b/src/main/g8/$name__norm$-stream-impl/src/main/resources/application.conf
@@ -18,21 +18,3 @@ Also note that this comment is a StringTemplate comment and is not included in t
 cassandra-journal.keyspace = \${$name;format="norm"$-stream.cassandra.keyspace}
 cassandra-snapshot-store.keyspace = \${$name;format="norm"$-stream.cassandra.keyspace}
 lagom.persistence.read-side.cassandra.keyspace = \${$name;format="norm"$-stream.cassandra.keyspace}
-
-
-# The properties below override Lagom default configuration with the recommended values for new projects.
-#
-# Lagom has not yet made these settings the defaults for backward-compatibility reasons.
-
-# Prefer 'ddata' over 'persistence' to share cluster sharding state for new projects.
-# See https://doc.akka.io/docs/akka/current/cluster-sharding.html#distributed-data-vs-persistence-mode
-akka.cluster.sharding.state-store-mode = ddata
-
-# Enable the serializer provided in Akka 2.5.8+ for akka.Done and other internal
-# messages to avoid the use of Java serialization.
-akka.actor.serialization-bindings {
-  "akka.Done"                 = akka-misc
-  "akka.NotUsed"              = akka-misc
-  "akka.actor.Address"        = akka-misc
-  "akka.remote.UniqueAddress" = akka-misc
-}


### PR DESCRIPTION
As of Akka 2.6 and Lagom 1.6, these settings are the same as the defaults and don't need to be repeated in the template.