### PR TITLE
workaround for scala-java8-compat semver issue

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,8 +1,13 @@
-organization in ThisBuild := "$organization$"
-version in ThisBuild := "$version$"
+ThisBuild / organization := "$organization$"
+ThisBuild / version := "$version$"
 
 // the Scala version that will be used for cross-compiled libraries
-scalaVersion in ThisBuild := "2.13.0"
+ThisBuild / scalaVersion  := "2.13.8"
+
+// Workaround for scala-java8-compat issue affecting Lagom dev-mode
+// https://github.com/lagom/lagom/issues/3344
+ThisBuild / libraryDependencySchemes +=
+  "org.scala-lang.modules" %% "scala-java8-compat" % VersionScheme.Always
 
 lazy val `$name;format="norm"$` = (project in file("."))
   .aggregate(`$name;format="norm"$-api`, `$name;format="norm"$-impl`, `$name;format="normalize"$-stream-api`, `$name;format="normalize"$-stream-impl`)

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.2


### PR DESCRIPTION
Adds workaround for https://github.com/lagom/lagom/issues/3344

Also taking the opportunity to upgrade to Scala 2.13.8 and Sbt 1.6.2

Credits go to @SethTisue that found the workaround.